### PR TITLE
build: mocha config with configurable reporter

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,25 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+const config = {
+  "enable-source-maps": true,
+  "throw-deprecation": true,
+  "timeout": 10000
+}
+if (process.env.MOCHA_REPORTER) {
+  config.reporter = process.env.MOCHA_REPORTER;
+}
+if (process.env.MOCHA_REPORTER_OUTPUT) {
+  config['reporter-option'] = `output=${process.env.MOCHA_REPORTER_OUTPUT}`;
+}
+module.exports = config;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
---require intelli-espower-loader
---require source-map-support/register
---throw-deprecation
---timeout 10000


### PR DESCRIPTION
This moves us to a modernized mocha configuration, we're using a `.js` file so that the reporter is configurable (this will allow us to output XML content for [buildcop](https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop)).