### PR TITLE
fix(coreos): handle coreos deprecation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -259,7 +259,9 @@ export class GCEImages {
       images = images.filter(this._filterDeprecated);
     }
 
-    if (images.length === 0) {
+    // All CoreOS images are now deprecated, See:
+    // https://cloud.google.com/compute/docs/eol/coreOS 
+    if (images.length === 0 && !osParts.name.startsWith('coreos')) {
       throw new Error('Could not find a suitable image.');
     }
     return images;

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ export class GCEImages {
     }
 
     // All CoreOS images are now deprecated, See:
-    // https://cloud.google.com/compute/docs/eol/coreOS 
+    // https://cloud.google.com/compute/docs/eol/coreOS
     if (images.length === 0 && !osParts.name.startsWith('coreos')) {
       throw new Error('Could not find a suitable image.');
     }

--- a/system-test/test.ts
+++ b/system-test/test.ts
@@ -74,6 +74,8 @@ describe('system tests', () => {
       const images = (await gceImages.getLatest()) as ImageMap;
       assert.strictEqual(typeof images, 'object');
       Object.keys(images).forEach(osName => {
+        // https://cloud.google.com/compute/docs/eol/coreOS
+        if (osName.startsWith('coreos')) return;
         assert.strictEqual(typeof images[osName], 'object');
       });
     });


### PR DESCRIPTION
All CoreOs images are now deprecated, which broke some of our logic:

https://cloud.google.com/compute/docs/eol/coreOS